### PR TITLE
Fix filtering and datetime conversion

### DIFF
--- a/src/modules/exercise2.py
+++ b/src/modules/exercise2.py
@@ -36,5 +36,10 @@ def aplica_neteja_noms(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def filtra_baells(df: pd.DataFrame) -> pd.DataFrame:
-    """Filtra les dades corresponents a La Baells."""
-    return df[df['estacio'] == 'La Baells'].copy()
+    """Filtra les dades corresponents a La Baells.
+
+    La funció ``neteja_nom_estacio`` pot deixar el nom de l'estació en minúscules
+    (``"la Baells"``). Per assegurar que el filtratge sempre funcioni, es fa la
+    comparació ignorant les majúscules/minúscules.
+    """
+    return df[df['estacio'].str.lower() == 'la baells'].copy()

--- a/src/modules/exercise3.py
+++ b/src/modules/exercise3.py
@@ -13,7 +13,7 @@ ALUMNE = "Francesc Lucas Carbo"
 
 def converteix_datetime(df: pd.DataFrame) -> pd.DataFrame:
     """Converteix la columna dia a tipus datetime i ordena."""
-    df['dia'] = pd.to_datetime(df['dia'])
+    df['dia'] = pd.to_datetime(df['dia'], dayfirst=True)
     df = df.sort_values('dia').reset_index(drop=True)
     return df
 


### PR DESCRIPTION
## Summary
- ensure `filtra_baells` matches "La Baells" regardless of case
- parse dates with day-first format when converting to `datetime`

## Testing
- `pytest -q`
- `python src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ff8e5ff48323945721c532a4e4ad