### PR TITLE
Fix imports path for running main as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Per executar tots els exercicis de manera consecutiva:
 ```bash
 python -m src.main
 ```
+Cal utilitzar l'opció `-m` per executar-lo com a mòdul i assegurar que els
+imports relatius funcionen correctament.
 
 També es pot indicar un exercici concret amb l'opció `-ex`:
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from modules import exercise1, exercise2, exercise3, exercise4, exercise5
+# Importa els mòduls utilitzant imports relatius per garantir
+# que funcionin tant en execucions locals com quan es fa
+# ``python -m src.main``
+from .modules import exercise1, exercise2, exercise3, exercise4, exercise5
 
 
 DATA_PATH = Path(__file__).resolve().parent.parent / 'data' / 'embassaments.csv'


### PR DESCRIPTION
## Summary
- fix relative imports in `main.py`
- clarify README instructions for running the app

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468eb53014832382e4503c0e9f4e8b