### PR TITLE
Display drought periods using full dates

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -69,7 +69,8 @@ def exec_ex4(df):
 def exec_ex5(df, suau):
     """Executa l'exercici 5 i mostra els períodes de sequera."""
     periodes = exercise5.calcula_periodes(df, suau)
-    print("Períodes de sequera:", periodes)
+    formatats = [[ini.strftime("%d/%m/%Y"), fi.strftime("%d/%m/%Y")] for ini, fi in periodes]
+    print("Períodes de sequera:", formatats)
     return periodes
 
 

--- a/src/modules/exercise5.py
+++ b/src/modules/exercise5.py
@@ -4,19 +4,23 @@ from typing import List
 import pandas as pd
 
 
-def calcula_periodes(df: pd.DataFrame, suau: pd.Series, llindar: float = 60.0) -> List[List[float]]:
-    """Calcula els períodes on el senyal suavitzat està per sota del llindar."""
+def calcula_periodes(df: pd.DataFrame, suau: pd.Series, llindar: float = 60.0) -> List[List[pd.Timestamp]]:
+    """Calcula els períodes on el senyal suavitzat està per sota del llindar.
+
+    Retorna una llista amb les dates d'inici i fi de cada període en format
+    ``pd.Timestamp``.
+    """
     en_sequera = suau < llindar
-    periodes = []
-    inici = None
+    periodes: List[List[pd.Timestamp]] = []
+    inici: pd.Timestamp | None = None
     for idx, en in en_sequera.items():
         if en and inici is None:
-            inici = df.loc[idx, 'dia_decimal']
+            inici = df.loc[idx, 'dia']
         elif not en and inici is not None:
-            fi = df.loc[idx - 1, 'dia_decimal']
-            periodes.append([float(inici), float(fi)])
+            fi = df.loc[idx - 1, 'dia']
+            periodes.append([inici, fi])
             inici = None
     if inici is not None:
-        fi = df.loc[en_sequera.index[-1], 'dia_decimal']
-        periodes.append([float(inici), float(fi)])
+        fi = df.loc[en_sequera.index[-1], 'dia']
+        periodes.append([inici, fi])
     return periodes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,9 @@ def test_suavitza_senyal():
 
 
 def test_calcula_periodes():
-    df = pd.DataFrame({'dia_decimal': [2020.0, 2021.0, 2022.0]})
+    df = pd.DataFrame({'dia': [pd.Timestamp('2020-01-01'),
+                               pd.Timestamp('2021-01-01'),
+                               pd.Timestamp('2022-01-01')]})
     suau = pd.Series([70, 50, 70])
     periodes = calcula_periodes(df, suau, llindar=60)
-    assert periodes == [[2021.0, 2021.0]]
+    assert periodes == [[pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-01')]]


### PR DESCRIPTION
## Summary
- return datetime periods in `calcula_periodes`
- show drought dates as day/month/year when running `exec_ex5`
- adapt unit test for new `calcula_periodes` output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cb9f4930832391bf02aeab1ea134